### PR TITLE
correct hill scoring

### DIFF
--- a/synergy/single/hill.py
+++ b/synergy/single/hill.py
@@ -92,6 +92,11 @@ class Hill(ParametricDoseResponseModel1D):
         super().fit(
             d / self._dose_scale, E, use_jacobian=use_jacobian, bootstrap_iterations=bootstrap_iterations, **kwargs
         )
+    
+    def _score(self, d_scaled, E):
+        # undo the internal scaling
+        d_original = d_scaled * self._dose_scale
+        super()._score(d_original, E)
 
     def _set_parameters(self, parameters):
         self.E0, self.Emax, self.h, self.C = parameters


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes bug in Hill model scoring.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
Override _score method in Hill.  The method as inherited from dose_response_model_1d uses the scaled dose 'd' as input to the E model, but the E model is fitted with the unscaled dose.  This mismatch leads to incorrect residuals and resultant metrics (R2, AIC, BIC).  Untransforming the 'd' in _score calc corrects this.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ x] I've read and followed all steps in the [Making a pull request](https://github.com/djwooten/synergy/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/djwooten/synergy/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
